### PR TITLE
numpy is a prerequisite for pypesq

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ With minimum specs, expects the whole process to take YYY hours.
     >   ERROR: Failed building wheel for pypesq
     > ERROR: Could not build wheels for pypesq, which is required to install pyproject.toml-based projects
     > ```
-    > you could manually install [`pypesq`](https://github.com/vBaiCai/python-pesq) in advance via:
+    > you could manually install [`pypesq`](https://github.com/vBaiCai/python-pesq) in advance via: 
+    > (make sure you have `numpy` installed before trying this to avoid compilation errors)
     > ```bash
     > python -m pip install https://github.com/vBaiCai/python-pesq/archive/master.zip
     > ```


### PR DESCRIPTION
I had to install `numpy` before manually installing `pypesq`. So I suggest to specify it in the README.md

```
(base) jhauret@megalodon:/mnt/sda1/dd/urgent2024_challenge$ pip install pypesq
Collecting pypesq
  Using cached pypesq-1.2.4.tar.gz (30 kB)
  Preparing metadata (setup.py) ... done
Collecting numpy (from pypesq)
  Using cached numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Using cached numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.0 MB)
Building wheels for collected packages: pypesq
  Building wheel for pypesq (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [30 lines of output]
      /home/jhauret/miniconda3/lib/python3.12/site-packages/setuptools/__init__.py:81: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!
      
              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
              ********************************************************************************
      
      !!
        dist.fetch_build_eggs(dist.setup_requires)
      running bdist_wheel
      running build
      running build_py
      file numpy.py (for module numpy) not found
      creating build
      creating build/lib.linux-x86_64-cpython-312
      creating build/lib.linux-x86_64-cpython-312/pypesq
      copying pypesq/__init__.py -> build/lib.linux-x86_64-cpython-312/pypesq
      file numpy.py (for module numpy) not found
      running build_ext
      building 'pesq_core' extension
      creating build/temp.linux-x86_64-cpython-312
      creating build/temp.linux-x86_64-cpython-312/pypesq
      gcc -pthread -B /home/jhauret/miniconda3/compiler_compat -fno-strict-overflow -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/jhauret/miniconda3/include -fPIC -O2 -isystem /home/jhauret/miniconda3/include -fPIC -Ipypesq -I/home/jhauret/miniconda3/include/python3.12 -I/tmp/pip-install-ee6w4r7_/pypesq_5958aa3816b841fc90a12c644e52774d/.eggs/numpy-2.0.0-py3.12-linux-x86_64.egg/numpy/_core/include -c pypesq/dsp.c -o build/temp.linux-x86_64-cpython-312/pypesq/dsp.o
      gcc -pthread -B /home/jhauret/miniconda3/compiler_compat -fno-strict-overflow -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/jhauret/miniconda3/include -fPIC -O2 -isystem /home/jhauret/miniconda3/include -fPIC -Ipypesq -I/home/jhauret/miniconda3/include/python3.12 -I/tmp/pip-install-ee6w4r7_/pypesq_5958aa3816b841fc90a12c644e52774d/.eggs/numpy-2.0.0-py3.12-linux-x86_64.egg/numpy/_core/include -c pypesq/pesq.c -o build/temp.linux-x86_64-cpython-312/pypesq/pesq.o
      pypesq/pesq.c:2:10: fatal error: arrayobject.h: No such file or directory
          2 | #include "arrayobject.h"
            |          ^~~~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for pypesq
  Running setup.py clean for pypesq
Failed to build pypesq
ERROR: Could not build wheels for pypesq, which is required to install pyproject.toml-based projects





(base) jhauret@megalodon:/mnt/sda1/dd/urgent2024_challenge$ pip install numpy
Collecting numpy
  Using cached numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
Using cached numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (19.0 MB)
Installing collected packages: numpy
Successfully installed numpy-2.0.0





(base) jhauret@megalodon:/mnt/sda1/dd/urgent2024_challenge$ pip install https://github.com/vBaiCai/python-pesq/archive/master.zip
Collecting https://github.com/vBaiCai/python-pesq/archive/master.zip
  Using cached https://github.com/vBaiCai/python-pesq/archive/master.zip
  Preparing metadata (setup.py) ... done
Requirement already satisfied: numpy in /home/jhauret/miniconda3/lib/python3.12/site-packages (from pypesq==1.2.4) (2.0.0)
Building wheels for collected packages: pypesq
  Building wheel for pypesq (setup.py) ... done
  Created wheel for pypesq: filename=pypesq-1.2.4-cp312-cp312-linux_x86_64.whl size=36064 sha256=2a506e55111b7e8dfe337e1a3640d0924d26a010cecfc07de90bddd6c49aab93
  Stored in directory: /tmp/pip-ephem-wheel-cache-9cwr6w_o/wheels/70/e0/70/75cdc8e97a2a1d69617d0a79facc6129d1c7d60329ab818d27
Successfully built pypesq
Installing collected packages: pypesq
Successfully installed pypesq-1.2.4

```